### PR TITLE
Support parallel simulation and simulator compilation

### DIFF
--- a/sim/vcs/__init__.py
+++ b/sim/vcs/__init__.py
@@ -296,7 +296,6 @@ class VCS(HammerSimTool, SynopsysTool):
 
         # Our current invocation of VCS is only using a single core
         if isinstance(self.submit_command, HammerLSFSubmitCommand):
-            #self.submit_command.settings.num_cpus = 1
             old_settings = self.submit_command.settings._asdict()
             del old_settings['num_cpus']
             self.submit_command.settings = HammerLSFSettings(num_cpus=1, **old_settings)


### PR DESCRIPTION
Currently based on #10 so we should merge that first.

This parallelizes two steps of the `sim` action.
First compilation is parallelized based on the number of cpus requested by the submit_command.
Second running the simulations are parallelized up to a maximum defined by the new key but each simulation is run with a single core because we are not currently enabling any of the optional runtime parallelism features.