### PR TITLE
Add support for passing LDFLAGS to VCS

### DIFF
--- a/sim/vcs/__init__.py
+++ b/sim/vcs/__init__.py
@@ -151,8 +151,12 @@ class VCS(HammerSimTool, SynopsysTool):
         for compiler_cc_opt in compiler_cc_opts:
             args.extend(['-CFLAGS', compiler_cc_opt])
 
+        # vcs requires libraries (-l) to be outside of the LDFLAGS
         for compiler_ld_opt in compiler_ld_opts:
-            args.extend(['-LDFLAGS', compiler_ld_opt])
+            if compiler_ld_opt.startswith('-l'):
+                args.extend([compiler_ld_opt])
+            else:
+                args.extend(['-LDFLAGS', compiler_ld_opt])
 
         # black box options
         args.extend(options)


### PR DESCRIPTION
This is linked to the following PR https://github.com/ucb-bar/chipyard/pull/650 https://github.com/ucb-bar/hammer/pull/591.

It adds preliminary support for passing `LDFLAGS` to VCS. Due to VCS being wonky it splits the `LDFLAGS` from the `-l*` libraries so that the `-l*` flags are put behind the objects using them (so that there is no "can't find X symbol errors"). 

It also changes the C compiler flags to be passed in by `CFLAGS`