### PR TITLE
Update plugin for verdi and ICVWV

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ IC Validator is very command-line driven. Here are some usage notes:
 * Extensibility is enabled by passing a file to the icv command with `-clf`. This file contains additional command line arguments, and is generated in the `generate_<drc/lvs>_args_file` step (can be overridden).
 * Decks are included using the `generate_<drc/lvs>_run_file` step (can be overridden with additional ICV method calls).
 * Results/violations are generated in a format readable by VUE (interactive violation browser) using the `-vue` option.
-* Layout is viewed using IC WorkBench Edit/View Plus (ICWBEV). It can communicate with VUE to generate violation markers by opening up a socket to ICV. The socket number can range between 1000 and 65535 (selectable by `<drc/lvs>.icv.icwbev_port`. Running the `generated_scripts/view_<drc/lvs>` script will handle this automatically, by starting ICWBEV, opening the port, waiting for it to be listening, and then starting VUE.
-* ICWBEV layer mapping can be specified in `synopsys.layerprops` key.
+* Layout is viewed using IC Validator Workbench (ICVBV). It can communicate with VUE to generate violation markers by opening up a socket to ICV. The socket number can range between 1000 and 65535 (selectable by `<drc/lvs>.icv.icvwb_port`. Running the `generated_scripts/view_<drc/lvs>` script will handle this automatically, by starting ICVWB, opening the port, waiting for it to be listening, and then starting VUE.
+* ICVWB layer mapping can be specified in `synopsys.layerprops` key.
 Tested with:
 * hammer-intech22-plugin

--- a/drc/icv/__init__.py
+++ b/drc/icv/__init__.py
@@ -82,11 +82,11 @@ class ICVDRC(HammerDRCTool):
 
         # TODO: check that drc run was successful
 
-        # Create view_drc script & icwbev macro script file
+        # Create view_drc script & icvwb macro script file
         # See the README for how this works
         os.makedirs(self.generated_scripts_dir, exist_ok=True)
 
-        with open(self.icwbev_macrofile, "w") as f:
+        with open(self.icvwb_macrofile, "w") as f:
             # Open socket
             f.write("user_socket open 0\n")
             # Layer mapping
@@ -98,17 +98,17 @@ class ICVDRC(HammerDRCTool):
             f.write("""
         cd {run_dir}
         source enter
-        # Start Synopsys IC WorkBench Edit/View Plus and wait for port to open before starting VUE
-        {icwbev} -socket {port} -run {macrofile} {gds} &
+        # Start Synopsys IC Validator WorkBench and wait for port to open before starting VUE
+        {icvwb} -socket {port} -run {macrofile} {gds} &
         while ! nc -z localhost {port}; do
             sleep 0.1
         done
         {icv_vue} -64 -load {results} -lay icwb -layArgs Port {port}
             """.format(
                 run_dir=self.run_dir,
-                icwbev=self.get_setting("drc.icv.icwbev_bin"),
-                port=self.get_setting("drc.icv.icwbev_port"),
-                macrofile=self.icwbev_macrofile,
+                icvwb=self.get_setting("drc.icv.icvwb_bin"),
+                port=self.get_setting("drc.icv.icvwb_port"),
+                macrofile=self.icvwb_macrofile,
                 gds=self.layout_file,
                 icv_vue=self.get_setting("drc.icv.icv_vue_bin"),
                 results=self.drc_results_db
@@ -166,8 +166,8 @@ class ICVDRC(HammerDRCTool):
         return os.path.join(self.generated_scripts_dir, "view_drc")
 
     @property
-    def icwbev_macrofile(self) -> str:
-        return os.path.join(self.generated_scripts_dir, "icwbev_macrofile")
+    def icvwb_macrofile(self) -> str:
+        return os.path.join(self.generated_scripts_dir, "icvwb_macrofile")
 
     @property
     def drc_run_file(self) -> str:

--- a/drc/icv/defaults.yml
+++ b/drc/icv/defaults.yml
@@ -7,20 +7,20 @@ drc.icv:
     icv_vue_bin: "${synopsys.synopsys_home}/icv/${drc.icv.version}/bin/LINUX.64/icv_vue"
     icv_vue_bin_meta: lazysubst
 
-    icwbev_bin: "${synopsys.synopsys_home}/icwbev_plus/${drc.icv.icwbev_version}/bin/icwbev"
-    icwbev_bin_meta: lazysubst
+    icvwb_bin: "${synopsys.synopsys_home}/icvwb/${drc.icv.icvwb_version}/bin/icvwb"
+    icvwb_bin_meta: lazysubst
 
     ICV_HOME_DIR: "${synopsys.synopsys_home}/icv/${drc.icv.version}"
     ICV_HOME_DIR_meta: lazysubst
 
     # type: str
-    version: "O-2018.06-SP2-3"
+    version: "S-2021.06-SP3-2"
     # type: str
-    icwbev_version: "O-2018.06-SP2"
-    # Port for VUE (violation browser) to communicate with ICWBEV (layout browser)
+    icvwb_version: "S-2021.06-SP2"
+    # Port for VUE (violation browser) to communicate with ICVWB (layout browser)
     # Any open port 1000 to 65536 allowed
     # type: int
-    icwbev_port: 1234
+    icvwb_port: 1234
 
     # Symbolic variables passed as -D flags to ICV command.
     # Alternatively, #define <var> <val> can be appended as additional_drc_text.
@@ -30,3 +30,4 @@ drc.icv:
     # Preprocessor include directories passed as -I to the ICV command.
     # type: List[str]
     include_dirs: []
+

--- a/lvs/icv/__init__.py
+++ b/lvs/icv/__init__.py
@@ -92,11 +92,11 @@ class ICVLVS(HammerLVSTool):
 
         # TODO: check that lvs run was successful
 
-        # Create view_lvs script & icwbev macro script file
+        # Create view_lvs script & icvwb macro script file
         # See the README for how this works
         os.makedirs(self.generated_scripts_dir, exist_ok=True)
 
-        with open(self.icwbev_macrofile, "w") as f:
+        with open(self.icvwb_macrofile, "w") as f:
             # Open socket
             f.write("user_socket open 0\n")
             # Layer mapping
@@ -108,17 +108,17 @@ class ICVLVS(HammerLVSTool):
             f.write("""
         cd {run_dir}
         source enter
-        # Start Synopsys IC WorkBench Edit/View Plus and wait for port to open before starting VUE
-        {icwbev} -socket {port} -run {macrofile} {gds} &
+        # Start Synopsys IC Validator WorkBench and wait for port to open before starting VUE
+        {icvwb} -socket {port} -run {macrofile} {gds} &
         while ! nc -z localhost {port}; do
             sleep 0.1
         done
         {icv_vue} -64 -load {results} -lay icwb -layArgs Port {port}
             """.format(
                 run_dir=self.run_dir,
-                icwbev=self.get_setting("lvs.icv.icwbev_bin"),
-                port=self.get_setting("lvs.icv.icwbev_port"),
-                macrofile=self.icwbev_macrofile,
+                icvwb=self.get_setting("lvs.icv.icvwb_bin"),
+                port=self.get_setting("lvs.icv.icvwb_port"),
+                macrofile=self.icvwb_macrofile,
                 gds=self.layout_file,
                 icv_vue=self.get_setting("lvs.icv.icv_vue_bin"),
                 results=self.lvs_results_db
@@ -207,8 +207,8 @@ class ICVLVS(HammerLVSTool):
         return os.path.join(self.generated_scripts_dir, "view_lvs")
 
     @property
-    def icwbev_macrofile(self) -> str:
-        return os.path.join(self.generated_scripts_dir, "icwbev_macrofile")
+    def icvwb_macrofile(self) -> str:
+        return os.path.join(self.generated_scripts_dir, "icvwb_macrofile")
 
     @property
     def lvs_run_file(self) -> str:

--- a/lvs/icv/defaults.yml
+++ b/lvs/icv/defaults.yml
@@ -10,20 +10,20 @@ lvs.icv:
     icv_vue_bin: "${synopsys.synopsys_home}/icv/${lvs.icv.version}/bin/LINUX.64/icv_vue"
     icv_vue_bin_meta: lazysubst
 
-    icwbev_bin: "${synopsys.synopsys_home}/icwbev_plus/${lvs.icv.icwbev_version}/bin/icwbev"
-    icwbev_bin_meta: lazysubst
+    icvwb_bin: "${synopsys.synopsys_home}/icvwb/${lvs.icv.icvwb_version}/bin/icvwb"
+    icvwb_bin_meta: lazysubst
 
     ICV_HOME_DIR: "${synopsys.synopsys_home}/icv/${lvs.icv.version}"
     ICV_HOME_DIR_meta: lazysubst
 
     # type: str
-    version: "O-2018.06-SP2-3"
+    version: "S-2021.06-SP3-2"
     # type: str
-    icwbev_version: "O-2018.06-SP2"
-    # Port for VUE (violation browser) to communicate with ICWBEV (layout browser)
+    icvwb_version: "S-2021.06-SP2"
+    # Port for VUE (violation browser) to communicate with ICVWB (layout browser)
     # Any open port 1000 to 65536 allowed
     # type: int
-    icwbev_port: 1234
+    icvwb_port: 1234
 
     # Symbolic variables passed as -D flags to ICV command.
     # Alternatively, #define <var> <val> can be appended as additional_lvs_text.

--- a/sim/vcs/__init__.py
+++ b/sim/vcs/__init__.py
@@ -76,6 +76,7 @@ class VCS(HammerSimTool, SynopsysTool):
     def env_vars(self) -> Dict[str, str]:
         v = dict(super().env_vars)
         v["VCS_HOME"] = self.get_setting("sim.vcs.vcs_home")
+        v["VERDI_HOME"] = self.get_setting("sim.vcs.verdi_home")
         v["SNPSLMD_LICENSE_FILE"] = self.get_setting("synopsys.SNPSLMD_LICENSE_FILE")
         return v
 

--- a/sim/vcs/defaults.yml
+++ b/sim/vcs/defaults.yml
@@ -6,6 +6,8 @@ sim.vcs:
   vcs_bin_meta: lazysubst
   vcs_home: "${synopsys.synopsys_home}/vcs/${sim.vcs.version}"
   vcs_home_meta: lazysubst
+  verdi_home: "${synopsys.synopsys_home}/verdi/${sim.vcs.version}"
+  verdi_home_meta: lazysubst
 
   # VCS version to use.
   # Used to locate the binary - e.g. the 'M-2017.03' in ${synopsys.synopsys_home}/vcs/M-2017.03/bin/vcs


### PR DESCRIPTION
 - DVE is deprecated, replaced with Verdi. Add flags to support VCS compile with Verdi support
 - ICWBEV is deprecated, replaced with ICVWB. Replace ICWBEV references with ICVWB