### PR TITLE
Auto-detect bus-delimiter for icv_nettran spice files

### DIFF
--- a/lvs/icv/__init__.py
+++ b/lvs/icv/__init__.py
@@ -147,7 +147,7 @@ class ICVLVS(HammerLVSTool):
         if unmatched:
             raise NotImplementedError("Unsupported netlist type for files: " + str(unmatched))
 
-        args = [self.get_setting("lvs.icv.icv_nettran_bin"), "-sp"]
+        args = [self.get_setting("lvs.icv.icv_nettran_bin"), "-sp-autoDetectBusdelimiter", "FIRST", "-sp"]
         args.extend(spice_files)
         args.extend(["-verilog"] + verilog_files)
         args.extend(["-outName", self.converted_icv_file])


### PR DESCRIPTION
Sometimes spice files use `<>` instead of `[]` for the bus delimiter.
This flag forces the tool to autodetect the delimiter from the input file.