### PR TITLE
Make FGP opt-in

### DIFF
--- a/sim/vcs/__init__.py
+++ b/sim/vcs/__init__.py
@@ -155,7 +155,7 @@ class VCS(HammerSimTool, SynopsysTool):
           "-debug_access+all" # since I-2014.03, req'd for FSDB dumping & force regs
         ]
 
-        if self.version() >= self.version_number("M-2017.03"):
+        if self.get_setting("sim.vcs.fgp") and self.version() >= self.version_number("M-2017.03"):
             args.append("-fgp")
 
         if timescale is not None:
@@ -329,7 +329,7 @@ class VCS(HammerSimTool, SynopsysTool):
         # setup simulation arguments
         args = [ self.simulator_executable_path ]
         args.extend(exec_flags_prepend)
-        if self.version() >= self.version_number("M-2017.03"):
+        if self.get_setting("sim.vcs.fgp") and self.version() >= self.version_number("M-2017.03"):
             # num_threads is in addition to a master thread, so reduce by 1
             num_threads=int(self.get_setting("vlsi.core.max_threads")) - 1
             args.append("-fgp=num_threads:{threads},num_fsdb_threads:0,allow_less_cores,dynamictoggle".format(threads=max(num_threads,1)))

--- a/sim/vcs/defaults.yml
+++ b/sim/vcs/defaults.yml
@@ -12,3 +12,8 @@ sim.vcs:
   # VCS version to use.
   # Used to locate the binary - e.g. the 'M-2017.03' in ${synopsys.synopsys_home}/vcs/M-2017.03/bin/vcs
   version: "P-2019.06-SP2-5"
+
+  # Option to turn on Fine-Grained Parallelism (FGP)
+  # Not all designs benefit from parallelized simulation.
+  # Use at your own risk - it is known to be buggy!
+  fgp: false


### PR DESCRIPTION
Many issues in Hammer & Chipyard are reporting odd simulation behavior when FGP is turned on. Examples:

- ucb-bar/hammer#674
- ucb-bar/hammer#650
- ucb-bar/hammer#643
- ucb-bar/hammer#642
- ucb-bar/chipyard#1211
- https://groups.google.com/u/1/g/chipyard/c/s41ND6XJtik/m/mR_QyIJ2AQAJ

Almost in all cases, threads don't seem to synchronize and the simulation hangs, despite fixing the issues with HTIF and ASAP7 SRAM models. Changing the FGP options given to VCS don't seem to help, and besides, most designs (Chipyard-based) don't benefit due to low EPC (ucb-bar/chipyard#1081).