### PR TITLE
Add -config_runset option

### DIFF
--- a/drc/icv/__init__.py
+++ b/drc/icv/__init__.py
@@ -9,7 +9,7 @@ from hammer_vlsi import HammerToolStep
 from hammer_vlsi import HammerDRCTool
 from hammer_logging import HammerVLSILogging
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import os
 import textwrap
@@ -155,6 +155,11 @@ class ICVDRC(HammerDRCTool):
             assert isinstance(include_dirs, list)
             if len(include_dirs) > 0:
                 f.write(" -I " + " -I ".join(include_dirs))
+
+            # Config runset file
+            config_rs = self.get_setting("drc.icv.config_runset")  # type: Optional[str]
+            if config_rs is not None:
+                f.write(" -config_runset" + config_rs)
         return True
 
     @property

--- a/drc/icv/defaults.yml
+++ b/drc/icv/defaults.yml
@@ -31,3 +31,7 @@ drc.icv:
     # type: List[str]
     include_dirs: []
 
+    # Config runset file passed in as -config_runset to the ICV command.
+    # Generally used for waivers.
+    # type: Optional[str]
+    config_runset: null

--- a/lvs/icv/__init__.py
+++ b/lvs/icv/__init__.py
@@ -11,7 +11,7 @@ from hammer_logging import HammerVLSILogging
 from hammer_utils import HammerFiletype, get_filetype
 import hammer_tech
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import os
 import textwrap
@@ -195,6 +195,11 @@ class ICVLVS(HammerLVSTool):
             assert isinstance(include_dirs, list)
             if len(include_dirs) > 0:
                 f.write(" -I " + " -I ".join(include_dirs))
+
+            # Config runset file
+            config_rs = self.get_setting("drc.icv.config_runset")  # type: Optional[str]
+            if config_rs is not None:
+                f.write(" -config_runset" + config_rs)
         return True
 
     @property

--- a/lvs/icv/defaults.yml
+++ b/lvs/icv/defaults.yml
@@ -33,3 +33,8 @@ lvs.icv:
     # Preprocessor include directories passed as -I to the ICV command.
     # type: List[str]
     include_dirs: []
+
+    # Config runset file passed in as -config_runset to the ICV command.
+    # Generally used to modify compare behavior.
+    # type: Optional[str]
+    config_runset: null


### PR DESCRIPTION
In DRC, used to add waiver databases.
In LVS, used to modify compare behavior.