### PR TITLE
-top should be optional

### DIFF
--- a/hammer/sim/vcs/__init__.py
+++ b/hammer/sim/vcs/__init__.py
@@ -207,7 +207,8 @@ class VCS(HammerSimTool, SynopsysTool):
             args.extend(["+delay_mode_zero"])
 
 
-        args.extend(["-top", tb_name])
+        if tb_name != "":
+            args.extend(["-top", tb_name])
 
         args.extend(['-o', self.simulator_executable_path])
 


### PR DESCRIPTION
If `sim.inputs.tb_name` is blank.

This is required for sims with new Hammer in Chipyard to work.